### PR TITLE
Remove transaction signing to API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,7 +1302,6 @@ dependencies = [
  "clap",
  "const-hex",
  "helm-core",
- "helm-net",
  "reqwest",
  "serde_json",
 ]

--- a/helm-cli/Cargo.toml
+++ b/helm-cli/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2024"
 [dependencies]
 # Local workspace crates
 helm-core = { path = "../helm-core" }
-helm-net = { path = "../helm-net", features = ["protocol"] }
 
 const-hex = "1.17.0"
 clap = { version = "4.5", features = ["derive"] }

--- a/helm-cli/src/main.rs
+++ b/helm-cli/src/main.rs
@@ -1,9 +1,12 @@
 use clap::{Parser, Subcommand};
 use const_hex as hex;
-use helm_core::{Hash, Signature, TransactionHash, commitment};
-use helm_core::{Input, Output, OutputId, Transaction, ledger::Query};
-use helm_net::protocol::NodeInfo;
+use helm_core::{Hash, TransactionHash, commitment, keypair};
+use helm_core::{Input, Output, OutputId, Transaction, ledger::Query, sighash};
 use std::time::Duration;
+
+// ============================================================================
+// CLI STRUCTURES
+// ============================================================================
 
 /// A CLI for interacting with the Eupp node via its HTTP REST API.
 #[derive(Parser, Debug)]
@@ -20,6 +23,10 @@ struct Cli {
 enum Command {
     /// Send a P2PKH transaction to a recipient identified by their public key hash (address).
     SendTo {
+        /// The secret key to sign the transaction with (hex-encoded).
+        #[arg(long)]
+        secret_key: String,
+
         /// The public key hash (address/commitment) of the recipient (hex-encoded, 32 bytes).
         #[arg(long)]
         address: Option<String>,
@@ -40,6 +47,10 @@ enum Command {
     Info,
 }
 
+// ============================================================================
+// UTILITY FUNCTIONS
+// ============================================================================
+
 fn build_client() -> reqwest::blocking::Client {
     reqwest::blocking::Client::builder()
         .timeout(Duration::from_secs(10))
@@ -51,32 +62,44 @@ fn base_url(peer: &str) -> String {
     peer.trim_end_matches('/').to_string()
 }
 
-fn cmd_send_to(peer: &str, address_hex: Option<&String>, amount: u64) {
+// ============================================================================
+// OUTPUT FORMATTING
+// ============================================================================
+
+fn print_section(title: &str) {
+    println!("\n╭─ {} ─────────────────────────────────────", title);
+}
+
+fn print_entry(key: &str, value: &str) {
+    println!("│  {:<25} {}", format!("{}:", key), value);
+}
+
+fn print_end_section() {
+    println!("╰────────────────────────────────────────────\n");
+}
+
+// ============================================================================
+// COMMAND HANDLERS
+// ============================================================================
+
+fn cmd_send_to(peer: &str, secret_key: &str, address_hex: Option<&String>, amount: u64) {
     let base = base_url(peer);
     let client = build_client();
 
-    // Fetch node info to get the public key
-    let resp = client
-        .get(format!("{base}/info"))
-        .send()
-        .expect("Failed to fetch info");
-
-    let node_info: NodeInfo = resp.json().expect("Failed to parse node info response");
-    let public_key = node_info.public_key;
-
-    // Parse the secret key
+    // --- Parse credentials ---
+    let secret_key = hex::decode_to_array(secret_key).expect("Invalid hex for secret key");
+    let signing_key = keypair(&secret_key);
+    let public_key = signing_key.verifying_key().to_bytes();
     let data = [0_u8; 32];
     let self_address = commitment(&public_key, Some(data.as_slice()));
 
-    // Parse the recipient address (public key hash / commitment)
+    // --- Parse recipient address ---
     let recipient_address: Hash = address_hex
         .map(|hex| hex::decode_to_array(hex).expect("Invalid hex for recipient address"))
         .unwrap_or(self_address);
 
-    // Build query for our own UTXOs
+    // --- Fetch UTXOs ---
     let query = Query::Addresses(vec![self_address]);
-
-    // Fetch UTXOs
     let resp = client
         .post(format!("{base}/outputs/search"))
         .json(&query)
@@ -90,58 +113,50 @@ fn cmd_send_to(peer: &str, address_hex: Option<&String>, amount: u64) {
     let outputs: Vec<(OutputId, Output)> = resp.json().expect("Failed to parse outputs response");
     let utxos = outputs.iter().take(255);
     let balance: u64 = utxos.clone().map(|(_, output)| output.amount()).sum();
-    println!("Address: {}", hex::encode_prefixed(self_address));
-    println!("Spendable balance: {} units", balance);
+
+    print_section("Wallet Information");
+    print_entry("Address", &hex::encode_prefixed(self_address));
+    print_entry("Spendable Balance", &format!("{} units", balance));
+    print_end_section();
 
     if amount > balance {
         panic!(
-            "Insufficient balance: have {} but trying to send {}",
+            "\n  ❌ Insufficient balance: have {} but trying to send {}",
             balance, amount
         );
     }
 
-    // Create outputs: one to the recipient (by address), one back to self for change
+    // --- Build transaction ---
     let data: Hash = [0u8; 32];
     let to_remote = Output::to_address(amount, &recipient_address, &data);
     let change = balance.saturating_sub(amount);
     let to_self = Output::new_v1(change, &public_key, &data);
     let new_outputs = vec![to_remote, to_self];
 
+    // --- Sign inputs ---
+    let sighash_val = sighash(utxos.clone().map(|(oid, _)| oid), &new_outputs);
+
     let inputs: Vec<Input> = utxos
         .clone()
         .map(|(output_id, _)| {
             Input::builder()
                 .with_output_id(*output_id)
-                .with_public_key(public_key)
+                .sign(signing_key.as_bytes(), sighash_val)
                 .build()
                 .unwrap()
         })
         .collect();
-    let mut tx = Transaction::new(inputs, new_outputs);
+    let tx = Transaction::new(inputs, new_outputs);
 
     let tx_hash = tx.hash();
-    println!(
-        "Constructed transaction with hash: 0x{}",
-        hex::encode(tx_hash)
-    );
+    print_section("Transaction Details");
+    print_entry("Hash", &format!("0x{}", hex::encode(tx_hash)));
+    print_entry("Amount", &format!("{} units", amount));
+    print_entry("Recipient", &hex::encode_prefixed(recipient_address));
+    print_entry("Change", &format!("{} units", change));
+    print_end_section();
 
-    // Sign the transaction
-    let resp = client
-        .post(format!("{base}/transactions/sign/all"))
-        .json(&tx)
-        .send()
-        .expect("Failed to sign transaction");
-    let signature: Signature = resp
-        .text()
-        .inspect(|t| println!("Signature: {t}"))
-        .map(hex::decode_to_array)
-        .unwrap()
-        .unwrap();
-    for input in &mut tx.inputs {
-        input.set_signature(signature);
-    }
-
-    // Broadcast
+    // --- Broadcast transaction ---
     let resp = client
         .post(format!("{base}/transactions"))
         .json(&tx)
@@ -157,21 +172,25 @@ fn cmd_send_to(peer: &str, address_hex: Option<&String>, amount: u64) {
 
     let broadcasted_hash: TransactionHash =
         resp.json().expect("Failed to parse broadcast response");
-    println!(
-        "Transaction {} broadcasted successfully.",
-        hex::encode_prefixed(broadcasted_hash)
-    );
+    print_section("Broadcast Status");
+    print_entry("Status", "✓ Success");
+    print_entry("Transaction Hash", &hex::encode_prefixed(broadcasted_hash));
+    print_end_section();
 }
 
 fn cmd_broadcast(peer: &str, tx_json: &str) {
     let base = base_url(peer);
     let client = build_client();
 
+    // --- Parse and display transaction ---
     let tx: Transaction = serde_json::from_str(tx_json).expect("Failed to parse transaction JSON");
-
     let tx_hash = tx.hash();
-    println!("Transaction hash: {}", hex::encode_prefixed(tx_hash));
 
+    print_section("Transaction Information");
+    print_entry("Hash", &hex::encode_prefixed(tx_hash));
+    print_end_section();
+
+    // --- Broadcast transaction ---
     let resp = client
         .post(format!("{base}/transactions"))
         .json(&tx)
@@ -187,16 +206,17 @@ fn cmd_broadcast(peer: &str, tx_json: &str) {
 
     let broadcasted_hash: TransactionHash =
         resp.json().expect("Failed to parse broadcast response");
-    println!(
-        "Transaction {} broadcasted successfully.",
-        hex::encode(broadcasted_hash)
-    );
+    print_section("Broadcast Status");
+    print_entry("Status", "✓ Success");
+    print_entry("Confirmed Hash", &hex::encode(broadcasted_hash));
+    print_end_section();
 }
 
 fn cmd_info(peer: &str) {
     let base = base_url(peer);
     let client = build_client();
 
+    // --- Fetch network info ---
     let resp = client
         .get(format!("{base}/info"))
         .send()
@@ -208,14 +228,24 @@ fn cmd_info(peer: &str) {
 
     let info: serde_json::Value = resp.json().expect("Failed to parse network info response");
 
+    print_section("Network Information");
     println!("{}", serde_json::to_string_pretty(&info).unwrap());
+    print_end_section();
 }
+
+// ============================================================================
+// MAIN ENTRY POINT
+// ============================================================================
 
 fn main() {
     let cli = Cli::parse();
 
     match cli.command {
-        Command::SendTo { address, amount } => cmd_send_to(&cli.peer, address.as_ref(), amount),
+        Command::SendTo {
+            secret_key,
+            address,
+            amount,
+        } => cmd_send_to(&cli.peer, &secret_key, address.as_ref(), amount),
         Command::Broadcast { tx } => cmd_broadcast(&cli.peer, &tx),
         Command::Info => cmd_info(&cli.peer),
     }

--- a/helm-net/src/node/mod.rs
+++ b/helm-net/src/node/mod.rs
@@ -145,34 +145,6 @@ impl RpcClient {
             resp => Err(RpcError::UnexpectedResponse(resp)),
         }
     }
-
-    /// Request to sign a transaction and return the signature.
-    pub async fn sigall_transaction(&self, tx: Transaction) -> Result<Signature, RpcError> {
-        match self
-            .request(RpcRequest::SignTransaction {
-                inputs: tx.inputs.iter().map(|i| i.output_id()).collect(),
-                outputs: tx.outputs,
-            })
-            .await?
-        {
-            RpcResponse::Signature(signature) => Ok(signature),
-            resp => Err(RpcError::UnexpectedResponse(resp)),
-        }
-    }
-
-    /// Request to partially sign a transaction and return the signature.
-    pub async fn sigout_transaction(&self, tx: Transaction) -> Result<Signature, RpcError> {
-        match self
-            .request(RpcRequest::SignTransaction {
-                inputs: vec![],
-                outputs: tx.outputs,
-            })
-            .await?
-        {
-            RpcResponse::Signature(signature) => Ok(signature),
-            resp => Err(RpcError::UnexpectedResponse(resp)),
-        }
-    }
 }
 
 /// Represents a full node in the Helm network.
@@ -670,12 +642,6 @@ impl<I: Send + Sync + 'static, M: Mempool + Send + Sync + 'static> HelmNode<I, M
                     }
                     Err(err) => Err(RpcError::BadRequest(err.to_string())),
                 }
-            }
-            RpcRequest::SignTransaction { inputs, outputs } => {
-                let signing_key = keypair(&self.config.secret_key());
-                let sighash = sighash(inputs.iter(), outputs.iter());
-                let signature = signing_key.sign(&sighash);
-                Ok(RpcResponse::Signature(signature.to_bytes()))
             }
         }
     }

--- a/helm-net/src/protocol.rs
+++ b/helm-net/src/protocol.rs
@@ -161,15 +161,6 @@ pub enum RpcRequest {
     /// Expect a `TransactionHash` in the response on success.
     BroadcastTransaction { tx: Transaction },
 
-    /// Request to sign a transaction.
-    /// Expect a `Signature` in the response on success.
-    SignTransaction {
-        /// The outputs being spent.
-        inputs: Vec<OutputId>,
-        /// The outputs being created.
-        outputs: Vec<Output>,
-    },
-
     /// Broadcast a mined block to the network.
     BroadcastBlock { block: Block },
 
@@ -206,13 +197,6 @@ pub enum RpcResponse {
 
     /// The summary of a block.
     BlockSummary(BlockSummary),
-
-    #[serde(
-        serialize_with = "serialize_to_hex",
-        deserialize_with = "deserialize_arr"
-    )]
-    /// The signature of the signed transaction.
-    Signature(Signature),
 }
 
 /// Error returned by a request made with [`crate::RpcClient`].

--- a/src/api.rs
+++ b/src/api.rs
@@ -50,8 +50,6 @@ pub fn router(state: RpcClient) -> Router {
         .route("/outputs/search", post(search_outputs))
         .route("/blocks/{hash}", get(get_block))
         .route("/transactions", post(send_raw_tx))
-        .route("/transactions/sign/all", post(sign_all_transaction))
-        .route("/transactions/sign/outputs", post(sign_outputs_transaction))
         .with_state(state)
 }
 
@@ -102,22 +100,6 @@ async fn get_block(
 ) -> Result<Json<BlockSummary>, ApiError> {
     let hash = parse_hex_hash(&block_hash_hex)?;
     Ok(Json(client.get_block_by_hash(hash).await?))
-}
-
-/// Sign all inputs and outputs of a transaction.
-async fn sign_all_transaction(
-    State(client): State<RpcClient>,
-    Json(tx): Json<Transaction>,
-) -> Result<String, ApiError> {
-    Ok(const_hex::encode(client.sigall_transaction(tx).await?))
-}
-
-/// Sign only the outputs of a transaction.
-async fn sign_outputs_transaction(
-    State(client): State<RpcClient>,
-    Json(tx): Json<Transaction>,
-) -> Result<String, ApiError> {
-    Ok(const_hex::encode(client.sigout_transaction(tx).await?))
 }
 
 /// Broadcast a transaction (create a new transaction resource).


### PR DESCRIPTION
The `transaction/sign` endpoints introduced a security risk as anyone could sign with the node's private key a transaction.